### PR TITLE
refactor(receipts): 🔄 replace OpenAI integration with n8n webhook for…

### DIFF
--- a/app/Livewire/Receipts/Create.php
+++ b/app/Livewire/Receipts/Create.php
@@ -143,7 +143,7 @@ class Create extends Component
                 ->post($webhookUrl);
 
             // Clean up temporary file if it was created by PdfConverter
-            if ($isTemporaryFile && \file_exists($imagePath)) {
+            if ($isTemporaryFile) {
                 @\unlink($imagePath);
             }
 

--- a/config/n8n.php
+++ b/config/n8n.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | n8n Webhook URL
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify your n8n webhook URL. This will be used to send
+    | receipt images for extraction.
+    */
+
+    'webhook_url' => \env('N8N_WEBHOOK_URL'),
+];
+
+

--- a/config/n8n.php
+++ b/config/n8n.php
@@ -10,9 +10,7 @@ return [
     |
     | Here you may specify your n8n webhook URL. This will be used to send
     | receipt images for extraction.
-    */
+     */
 
     'webhook_url' => \env('N8N_WEBHOOK_URL'),
 ];
-
-


### PR DESCRIPTION
… receipt data extraction

* Updated the `extractFromImage` method to utilize an n8n webhook instead of OpenAI for processing receipt images.
* Added configuration for n8n webhook URL in a new `n8n.php` config file.
* Removed obsolete methods related to OpenAI file uploads and thread management.