### PR TITLE
feat(receipts): 🎉 add batch retrieval for receipt items

### DIFF
--- a/app/Mcp/Receipts/ReceiptMcpItemPayload.php
+++ b/app/Mcp/Receipts/ReceiptMcpItemPayload.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Receipts;
+
+use App\Models\ReceiptItem;
+
+final class ReceiptMcpItemPayload
+{
+    /**
+     * @return array{id: int, name: string, quantity: int, amount: mixed, category_id: int, category_name: null|string}
+     */
+    public static function row(ReceiptItem $item): array
+    {
+        return [
+            'id' => $item->id,
+            'name' => $item->name,
+            'quantity' => $item->quantity,
+            'amount' => $item->amount,
+            'category_id' => $item->category_id,
+            'category_name' => $item->category?->name,
+        ];
+    }
+}

--- a/app/Mcp/Servers/ReceiptServer.php
+++ b/app/Mcp/Servers/ReceiptServer.php
@@ -6,6 +6,7 @@ namespace App\Mcp\Servers;
 
 use App\Mcp\Tools\Receipts\CreateReceiptTool;
 use App\Mcp\Tools\Receipts\GetReceiptImageTool;
+use App\Mcp\Tools\Receipts\GetReceiptItemsBatchTool;
 use App\Mcp\Tools\Receipts\GetReceiptItemsTool;
 use App\Mcp\Tools\Receipts\ListReceiptCategoriesTool;
 use App\Mcp\Tools\Receipts\ListReceiptsTool;
@@ -23,7 +24,7 @@ This server manages the signed-in user's receipts (metadata, line items, and sto
 
 **Authentication:** OAuth 2.1 via Laravel Passport. Clients must obtain an access token that includes the **`mcp:use`** scope, then send `Authorization: Bearer <token>` on every MCP HTTP request.
 
-**Tools:** Call **`receipt_list_categories`** when you need valid **`category_id`** values for line items. **`receipt_list`** returns receipt summaries only (no line items) to keep context small; optional **`from`** / **`to`** filters use **YYYY-MM-DD** inclusive. Use **`receipt_get_items`** with **`receipt_id`** to load line items. **`receipt_create`** requires header fields, at least one line item, and a **documentation image**: **`image_base64`** plus **`image_mime_type`** (`image/jpeg`, `image/png`, or `application/pdf`; max **15 MiB** decoded). **`receipt_update`** changes receipt metadata only; **`receipt_items_update`** replaces **all** line items for a receipt. **`receipt_get_image`** returns the stored scan for multimodal clients.
+**Tools:** Call **`receipt_list_categories`** when you need valid **`category_id`** values for line items. **`receipt_list`** returns receipt summaries only (no line items) to keep context small; optional **`from`** / **`to`** filters use **YYYY-MM-DD** inclusive. Use **`receipt_get_items`** with **`receipt_id`** for one receipt, or **`receipt_get_items_batch`** with **`receipt_ids`** (array, up to 200) to load line items for many receipts in one round trip (for statistics). **`receipt_create`** requires header fields, at least one line item, and a **documentation image**: **`image_base64`** plus **`image_mime_type`** (`image/jpeg`, `image/png`, or `application/pdf`; max **15 MiB** decoded). **`receipt_update`** changes receipt metadata only; **`receipt_items_update`** replaces **all** line items for a receipt. **`receipt_get_image`** returns the stored scan for multimodal clients.
 
 **MCP endpoint:** HTTP `POST` to `/mcp/receipts` on this app’s base URL (copy from the web app under **MCP & OAuth (AI assistants)** in the side menu).
 MARKDOWN)]
@@ -33,6 +34,7 @@ class ReceiptServer extends Server
         ListReceiptCategoriesTool::class,
         ListReceiptsTool::class,
         GetReceiptItemsTool::class,
+        GetReceiptItemsBatchTool::class,
         CreateReceiptTool::class,
         UpdateReceiptTool::class,
         UpdateReceiptItemsTool::class,

--- a/app/Mcp/Tools/Receipts/GetReceiptItemsBatchTool.php
+++ b/app/Mcp/Tools/Receipts/GetReceiptItemsBatchTool.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools\Receipts;
+
+use App\Mcp\Receipts\ReceiptMcpItemPayload;
+use App\Models\Receipt;
+use App\Models\ReceiptItem;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[Name(value: 'receipt_get_items_batch')]
+#[Description(value: 'Fetch line items for one or many receipts in a single call (for statistics). Only receipts owned by the user are returned; unknown ids are listed separately.')]
+#[IsReadOnly(value: true)]
+class GetReceiptItemsBatchTool extends Tool
+{
+    private const MAX_RECEIPTS = 200;
+
+    public function handle(Request $request): Response | ResponseFactory
+    {
+        $userId = \auth()->id();
+
+        if (!\is_int($userId)) {
+            return Response::error('Unauthenticated.');
+        }
+
+        /** @var array{receipt_ids: list<int>} $validated */
+        $validated = $request->validate([
+            'receipt_ids' => 'required|array|min:1|max:' . self::MAX_RECEIPTS,
+            'receipt_ids.*' => 'integer|distinct',
+        ]);
+
+        $requested = \array_values(\array_unique($validated['receipt_ids']));
+
+        $validIdsFromDb = [];
+        $validSet = [];
+
+        foreach (Receipt::forAuthUser()->whereIn('id', $requested)->pluck('id') as $id) {
+            if (\is_int($id)) {
+                $validIdsFromDb[] = $id;
+                $validSet[$id] = true;
+            } elseif (\is_string($id) && \ctype_digit($id)) {
+                $intId = (int) $id;
+                $validIdsFromDb[] = $intId;
+                $validSet[$intId] = true;
+            }
+        }
+        $missingReceiptIds = [];
+
+        foreach ($requested as $rid) {
+            if (!isset($validSet[$rid])) {
+                $missingReceiptIds[] = $rid;
+            }
+        }
+
+        if ($validIdsFromDb === []) {
+            return Response::structured([
+                'receipts' => [],
+                'missing_receipt_ids' => $missingReceiptIds,
+            ]);
+        }
+
+        $items = ReceiptItem::query()
+            ->whereIn('receipt_id', $validIdsFromDb)
+            ->with('category')
+            ->orderBy('receipt_id')
+            ->orderBy('id')
+            ->get();
+
+        /** @var array<int, list<array<string, mixed>>> $byReceiptId */
+        $byReceiptId = [];
+
+        foreach ($items as $item) {
+            $byReceiptId[$item->receipt_id][] = ReceiptMcpItemPayload::row($item);
+        }
+
+        $receipts = [];
+
+        foreach ($requested as $rid) {
+            if (!isset($validSet[$rid])) {
+                continue;
+            }
+
+            $receipts[] = [
+                'receipt_id' => $rid,
+                'items' => $byReceiptId[$rid] ?? [],
+            ];
+        }
+
+        return Response::structured([
+            'receipts' => $receipts,
+            'missing_receipt_ids' => $missingReceiptIds,
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'receipt_ids' => $schema->array()
+                ->items($schema->integer())
+                ->min(1)
+                ->max(self::MAX_RECEIPTS)
+                ->description('Receipt ids to load line items for (max ' . self::MAX_RECEIPTS . ', distinct).')
+                ->required(),
+        ];
+    }
+}

--- a/app/Mcp/Tools/Receipts/GetReceiptItemsTool.php
+++ b/app/Mcp/Tools/Receipts/GetReceiptItemsTool.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Mcp\Tools\Receipts;
 
+use App\Mcp\Receipts\ReceiptMcpItemPayload;
 use App\Models\Receipt;
 use App\Models\ReceiptItem;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
@@ -43,16 +44,7 @@ class GetReceiptItemsTool extends Tool
 
         return Response::structured([
             'receipt_id' => $receipt->id,
-            'items' => $items->map(static function (ReceiptItem $item): array {
-                return [
-                    'id' => $item->id,
-                    'name' => $item->name,
-                    'quantity' => $item->quantity,
-                    'amount' => $item->amount,
-                    'category_id' => $item->category_id,
-                    'category_name' => $item->category?->name,
-                ];
-            })->values()->all(),
+            'items' => $items->map(static fn(ReceiptItem $item) => ReceiptMcpItemPayload::row($item))->values()->all(),
         ]);
     }
 

--- a/tests/Feature/Mcp/ReceiptMcpServerTest.php
+++ b/tests/Feature/Mcp/ReceiptMcpServerTest.php
@@ -180,6 +180,43 @@ function receiptMcpSessionId(TestCase $test, User $user): string
     $call->assertJsonPath('result.structuredContent.items.0.category_name', 'Food');
 })->covers(ReceiptServer::class);
 
+\test('mcp receipt_get_items_batch returns items for multiple receipts', function (): void {
+    Storage::fake('wasabi');
+    $user = User::factory()->create();
+    $cat = ReceiptCategory::factory()->for($user)->create();
+
+    $r1 = Receipt::factory()->for($user)->create();
+    ReceiptItem::factory()->for($r1)->create(['name' => 'A', 'quantity' => 1, 'amount' => 1.0, 'category_id' => $cat->id]);
+
+    $r2 = Receipt::factory()->for($user)->create();
+    ReceiptItem::factory()->for($r2)->create(['name' => 'B', 'quantity' => 2, 'amount' => 3.0, 'category_id' => $cat->id]);
+
+    $sessionId = \receiptMcpSessionId($this, $user);
+    $ghostId = 9_999_999;
+
+    $call = $this->postJson('/mcp/receipts', [
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'method' => 'tools/call',
+        'params' => [
+            'name' => 'receipt_get_items_batch',
+            'arguments' => [
+                'receipt_ids' => [$r2->id, $r1->id, $ghostId],
+            ],
+        ],
+    ], [
+        'MCP-Session-Id' => $sessionId,
+    ]);
+
+    $call->assertStatus(200);
+    $call->assertJsonPath('result.isError', false);
+    $call->assertJsonPath('result.structuredContent.receipts.0.receipt_id', $r2->id);
+    $call->assertJsonPath('result.structuredContent.receipts.0.items.0.name', 'B');
+    $call->assertJsonPath('result.structuredContent.receipts.1.receipt_id', $r1->id);
+    $call->assertJsonPath('result.structuredContent.receipts.1.items.0.name', 'A');
+    $call->assertJsonPath('result.structuredContent.missing_receipt_ids.0', $ghostId);
+})->covers(ReceiptServer::class);
+
 \test('mcp receipt_create stores receipt image and items', function (): void {
     Storage::fake('wasabi');
     $user = User::factory()->create();


### PR DESCRIPTION
* Introduced GetReceiptItemsBatchTool to fetch line items for multiple receipts in a single request, enhancing efficiency for user operations.
* Updated ReceiptServer to include the new tool, allowing for batch processing of receipt item requests.
* Refactored GetReceiptItemsTool to utilize ReceiptMcpItemPayload for consistent item response formatting.
* Added tests to ensure correct functionality of the batch retrieval feature, verifying response structure and handling of missing receipt IDs.