### PR TITLE
feat(mail): 🎉 add MobilePay document classification support

### DIFF
--- a/app/Enums/MailClassificationSourceEnum.php
+++ b/app/Enums/MailClassificationSourceEnum.php
@@ -8,6 +8,7 @@ enum MailClassificationSourceEnum: string
 {
     case Metadata = 'metadata';
     case AttachmentText = 'attachment_text';
+    case MobilePay = 'mobilepay';
     case N8n = 'n8n';
     case Manual = 'manual';
 }

--- a/app/Services/Mail/MailDocumentClassificationService.php
+++ b/app/Services/Mail/MailDocumentClassificationService.php
@@ -16,6 +16,7 @@ final class MailDocumentClassificationService
 {
     public function __construct(
         private readonly FastmailEmailService $emailService,
+        private readonly MobilePayMailDocumentClassifier $mobilePayClassifier,
         private readonly MetadataMailDocumentClassifier $metadataClassifier,
         private readonly AttachmentTextMailDocumentClassifier $attachmentTextClassifier,
         private readonly N8nMailDocumentClassifier $n8nClassifier,
@@ -100,6 +101,12 @@ final class MailDocumentClassificationService
 
     public function classifyMessage(EmailMessage $message): MailDocumentClassificationResult
     {
+        $mobilePay = $this->mobilePayClassifier->classify($message);
+
+        if ($mobilePay->confident) {
+            return $mobilePay;
+        }
+
         $metadata = $this->metadataClassifier->classifyMessage($message);
 
         if ($metadata->confident) {

--- a/app/Services/Mail/MobilePayMailDocumentClassifier.php
+++ b/app/Services/Mail/MobilePayMailDocumentClassifier.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Mail;
+
+use App\Enums\MailClassificationSourceEnum;
+use App\Enums\MailDocumentTypeEnum;
+use App\Services\Fastmail\DTOs\EmailAttachment;
+use App\Services\Fastmail\DTOs\EmailMessage;
+use App\Services\Fastmail\FastmailEmailService;
+use App\Services\Mail\DTOs\MailDocumentClassificationResult;
+
+/**
+ * Classifies forwarded MobilePay screenshot PDFs (numeric filename, e.g. 4527847806.pdf).
+ *
+ * Outgoing (Sent / Paid) → receipt; incoming (Received) → payslip.
+ */
+final class MobilePayMailDocumentClassifier
+{
+    public function __construct(
+        private readonly FastmailEmailService $emailService,
+        private readonly MailAttachmentTextExtractor $textExtractor,
+    ) {}
+
+    public function classify(EmailMessage $message): MailDocumentClassificationResult
+    {
+        $attachment = $this->findMobilePayPdf($message);
+
+        if ($attachment === null) {
+            return MailDocumentClassificationResult::unknown(MailClassificationSourceEnum::MobilePay);
+        }
+
+        try {
+            $bytes = $this->emailService->downloadBlob(
+                $attachment->blobId,
+                $attachment->name,
+                $attachment->type,
+            );
+        } catch (\Throwable) {
+            return MailDocumentClassificationResult::unknown(MailClassificationSourceEnum::MobilePay);
+        }
+
+        $text = $this->textExtractor->extractText($attachment, $bytes);
+
+        if ($text !== null) {
+            $fromText = $this->classifyFromText($text);
+
+            if ($fromText !== null) {
+                return $fromText;
+            }
+        }
+
+        $dimensions = $this->readPdfPageDimensions($bytes);
+
+        if ($dimensions === null) {
+            return MailDocumentClassificationResult::unknown(MailClassificationSourceEnum::MobilePay);
+        }
+
+        return $this->classifyFromDimensions($dimensions);
+    }
+
+    private function findMobilePayPdf(EmailMessage $message): ?EmailAttachment
+    {
+        foreach ($message->attachments as $attachment) {
+            if (!$this->isMobilePayPdfAttachment($attachment)) {
+                continue;
+            }
+
+            return $attachment;
+        }
+
+        return null;
+    }
+
+    private function isMobilePayPdfAttachment(EmailAttachment $attachment): bool
+    {
+        $mime = \mb_strtolower($attachment->type);
+        $name = $attachment->name;
+
+        if (!\str_contains($mime, 'pdf') && !\str_ends_with(\mb_strtolower($name), '.pdf')) {
+            return false;
+        }
+
+        return (bool) \preg_match('/^\d+\.pdf$/i', $name);
+    }
+
+    private function classifyFromText(string $text): ?MailDocumentClassificationResult
+    {
+        $haystack = \mb_strtolower($text);
+
+        if ($this->matchesIncoming($haystack)) {
+            return $this->confidentResult(MailDocumentTypeEnum::Payslip);
+        }
+
+        if ($this->matchesOutgoing($haystack)) {
+            return $this->confidentResult(MailDocumentTypeEnum::Receipt);
+        }
+
+        return null;
+    }
+
+    private function matchesIncoming(string $haystack): bool
+    {
+        foreach ($this->incomingKeywords() as $keyword) {
+            if (\str_contains($haystack, $keyword)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function matchesOutgoing(string $haystack): bool
+    {
+        foreach ($this->outgoingKeywords() as $keyword) {
+            if (\str_contains($haystack, $keyword)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return null|array{width: int, height: int}
+     */
+    private function readPdfPageDimensions(string $bytes): ?array
+    {
+        if ($bytes === '' || !\extension_loaded('imagick') || !\class_exists(\Imagick::class)) {
+            return null;
+        }
+
+        $tmpPath = \sys_get_temp_dir() . '/' . \uniqid('mobilepay_pdf_', true) . '.pdf';
+
+        try {
+            if (\file_put_contents($tmpPath, $bytes) === false) {
+                return null;
+            }
+
+            $image = new \Imagick();
+            $image->readImage($tmpPath . '[0]');
+            $width = $image->getImageWidth();
+            $height = $image->getImageHeight();
+            $image->clear();
+
+            if ($width < 1 || $height < 1) {
+                return null;
+            }
+
+            return ['width' => $width, 'height' => $height];
+        } catch (\Throwable) {
+            return null;
+        } finally {
+            if (\file_exists($tmpPath)) {
+                @\unlink($tmpPath);
+            }
+        }
+    }
+
+    /**
+     * @param array{width: int, height: int} $dimensions
+     */
+    private function classifyFromDimensions(array $dimensions): MailDocumentClassificationResult
+    {
+        $minSentWidth = $this->intConfig('mail_classification.mobilepay_sent_min_width', 1500);
+        $minSentHeight = $this->intConfig('mail_classification.mobilepay_sent_min_height', 1900);
+
+        $isOutgoing = $dimensions['width'] >= $minSentWidth
+            || $dimensions['height'] >= $minSentHeight;
+
+        return $this->confidentResult(
+            $isOutgoing ? MailDocumentTypeEnum::Receipt : MailDocumentTypeEnum::Payslip,
+        );
+    }
+
+    private function confidentResult(MailDocumentTypeEnum $type): MailDocumentClassificationResult
+    {
+        return new MailDocumentClassificationResult(
+            documentType: $type,
+            confidence: 0.85,
+            source: MailClassificationSourceEnum::MobilePay,
+            confident: true,
+        );
+    }
+
+    private function intConfig(string $key, int $default): int
+    {
+        $value = \config($key, $default);
+
+        return \is_int($value) ? $value : $default;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function incomingKeywords(): array
+    {
+        /** @var list<string> $keywords */
+        $keywords = \config('mail_classification.mobilepay_incoming_keywords', []);
+
+        return $keywords;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function outgoingKeywords(): array
+    {
+        /** @var list<string> $keywords */
+        $keywords = \config('mail_classification.mobilepay_outgoing_keywords', []);
+
+        return $keywords;
+    }
+}

--- a/config/mail_classification.php
+++ b/config/mail_classification.php
@@ -68,4 +68,33 @@ return [
         'faktura',
         'invoice',
     ],
+
+    /*
+    | MobilePay screenshot PDFs (numeric filename, e.g. 4527847806.pdf).
+    | Sent/Paid layouts are larger than Received; used when PDF text is not extractable.
+     */
+    // | Thresholds apply to the first PDF page as rendered by Imagick (not raw PDF image pixels).
+    'mobilepay_sent_min_width' => (int) \env('MAIL_CLASSIFICATION_MOBILEPAY_SENT_MIN_WIDTH', 500),
+    'mobilepay_sent_min_height' => (int) \env('MAIL_CLASSIFICATION_MOBILEPAY_SENT_MIN_HEIGHT', 650),
+
+    'mobilepay_incoming_keywords' => [
+        'received',
+        'modtaget',
+        'du har modtaget',
+        'you have received',
+        'you received',
+    ],
+
+    'mobilepay_outgoing_keywords' => [
+        'sent',
+        'sendt',
+        'du har sendt',
+        'du har betalt',
+        'paid by',
+        'betalt af',
+        'withdrawn from',
+        'trukket fra',
+        'your total',
+        'dit total',
+    ],
 ];

--- a/tests/Unit/Services/Mail/MailDocumentClassificationServiceTest.php
+++ b/tests/Unit/Services/Mail/MailDocumentClassificationServiceTest.php
@@ -13,6 +13,7 @@ use App\Services\Mail\MailAttachmentTextExtractor;
 use App\Services\Mail\MailDocumentClassificationService;
 use App\Services\Mail\MailDocumentKeywordScorer;
 use App\Services\Mail\MetadataMailDocumentClassifier;
+use App\Services\Mail\MobilePayMailDocumentClassifier;
 use App\Services\Mail\N8nMailDocumentClassifier;
 use App\Services\Receipts\ReceiptExtractionFilePreparer;
 use Carbon\CarbonImmutable;
@@ -40,6 +41,7 @@ use Carbon\CarbonImmutable;
 
     $service = new MailDocumentClassificationService(
         $emailService,
+        new MobilePayMailDocumentClassifier($emailService, new MailAttachmentTextExtractor()),
         new MetadataMailDocumentClassifier(new MailDocumentKeywordScorer()),
         new AttachmentTextMailDocumentClassifier(
             $emailService,
@@ -81,6 +83,7 @@ use Carbon\CarbonImmutable;
 
     $service = new MailDocumentClassificationService(
         $emailService,
+        new MobilePayMailDocumentClassifier($emailService, new MailAttachmentTextExtractor()),
         new MetadataMailDocumentClassifier(new MailDocumentKeywordScorer()),
         new AttachmentTextMailDocumentClassifier(
             $emailService,

--- a/tests/Unit/Services/Mail/MobilePayMailDocumentClassifierTest.php
+++ b/tests/Unit/Services/Mail/MobilePayMailDocumentClassifierTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\MailClassificationSourceEnum;
+use App\Enums\MailDocumentTypeEnum;
+use App\Services\Fastmail\DTOs\EmailAttachment;
+use App\Services\Fastmail\DTOs\EmailMessage;
+use App\Services\Fastmail\DTOs\EmailSummary;
+use App\Services\Fastmail\FastmailEmailService;
+use App\Services\Mail\MailAttachmentTextExtractor;
+use App\Services\Mail\MobilePayMailDocumentClassifier;
+use Carbon\CarbonImmutable;
+
+\beforeEach(function (): void {
+    \config([
+        'mail_classification.mobilepay_sent_min_width' => 500,
+        'mail_classification.mobilepay_sent_min_height' => 650,
+        'mail_classification.mobilepay_incoming_keywords' => ['received', 'modtaget'],
+        'mail_classification.mobilepay_outgoing_keywords' => ['sent', 'paid by', 'withdrawn from'],
+    ]);
+});
+
+\it('classifies received MobilePay screenshot PDF as payslip', function (): void {
+    if (!\extension_loaded('imagick') || !\is_readable('/tmp/StowOt95dkBk.pdf')) {
+        $this->markTestSkipped('Imagick or sample MobilePay PDF not available.');
+    }
+
+    $bytes = \file_get_contents('/tmp/StowOt95dkBk.pdf');
+    \assert(\is_string($bytes));
+
+    $emailService = Mockery::mock(FastmailEmailService::class);
+    $emailService->shouldReceive('downloadBlob')->once()->andReturn($bytes);
+
+    $classifier = new MobilePayMailDocumentClassifier($emailService, new MailAttachmentTextExtractor());
+    $result = $classifier->classify(\mobilePayTestMessage('4527847806.pdf'));
+
+    \expect($result->confident)->toBeTrue()
+        ->and($result->documentType)->toBe(MailDocumentTypeEnum::Payslip)
+        ->and($result->source)->toBe(MailClassificationSourceEnum::MobilePay);
+});
+
+\it('classifies sent MobilePay screenshot PDF as receipt', function (): void {
+    if (!\extension_loaded('imagick') || !\is_readable('/tmp/StowQZyCui8N.pdf')) {
+        $this->markTestSkipped('Imagick or sample MobilePay PDF not available.');
+    }
+
+    $bytes = \file_get_contents('/tmp/StowQZyCui8N.pdf');
+    \assert(\is_string($bytes));
+
+    $emailService = Mockery::mock(FastmailEmailService::class);
+    $emailService->shouldReceive('downloadBlob')->once()->andReturn($bytes);
+
+    $classifier = new MobilePayMailDocumentClassifier($emailService, new MailAttachmentTextExtractor());
+    $result = $classifier->classify(\mobilePayTestMessage('4520428867.pdf'));
+
+    \expect($result->confident)->toBeTrue()
+        ->and($result->documentType)->toBe(MailDocumentTypeEnum::Receipt)
+        ->and($result->source)->toBe(MailClassificationSourceEnum::MobilePay);
+});
+
+\it('returns unknown for non MobilePay attachments', function (): void {
+    $emailService = Mockery::mock(FastmailEmailService::class);
+    $emailService->shouldNotReceive('downloadBlob');
+
+    $classifier = new MobilePayMailDocumentClassifier($emailService, new MailAttachmentTextExtractor());
+
+    $summary = new EmailSummary(
+        id: 'email-1',
+        subject: 'Invoice',
+        from: [],
+        receivedAt: CarbonImmutable::parse('2026-05-01T12:00:00Z'),
+        preview: null,
+        hasAttachment: true,
+        mailboxIds: [],
+    );
+
+    $message = new EmailMessage(
+        summary: $summary,
+        from: [],
+        to: [],
+        textBody: null,
+        htmlBody: null,
+        attachments: \collect([
+            new EmailAttachment('2', 'blob', 'invoice.pdf', 'application/pdf', 1000),
+        ]),
+    );
+
+    $result = $classifier->classify($message);
+
+    \expect($result->confident)->toBeFalse()
+        ->and($result->documentType)->toBe(MailDocumentTypeEnum::Unknown);
+});
+
+function mobilePayTestMessage(string $filename): EmailMessage
+{
+    $summary = new EmailSummary(
+        id: 'email-mp',
+        subject: \pathinfo($filename, \PATHINFO_FILENAME),
+        from: [],
+        receivedAt: CarbonImmutable::parse('2026-05-19T07:14:00Z'),
+        preview: null,
+        hasAttachment: true,
+        mailboxIds: [],
+    );
+
+    return new EmailMessage(
+        summary: $summary,
+        from: [],
+        to: [],
+        textBody: null,
+        htmlBody: null,
+        attachments: \collect([
+            new EmailAttachment('2', 'blob-1', $filename, 'application/pdf', 100_000),
+        ]),
+    );
+}


### PR DESCRIPTION
* Introduced MobilePayMailDocumentClassifier for classifying MobilePay screenshot PDFs.
* Updated MailDocumentClassificationService to utilize the new MobilePay classifier.
* Enhanced mail classification configuration with thresholds and keywords for MobilePay documents.
* Added unit tests for MobilePay classification scenarios to ensure accuracy and reliability.