### PR TITLE
ci(docker): split base image and optimise build pipeline

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,42 +1,77 @@
 name: Docker
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 on:
   push:
-    tags: ["v*.*.*"]
+    branches:
+      - main
 
 jobs:
-  build:
+  changes:
     runs-on: ubuntu-latest
+    outputs:
+      base_changed: ${{ steps.filter.outputs.base_changed }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            base_changed:
+              - 'Dockerfile.base.production'
+              - '.github/workflows/docker-publish.yml'
+
+  build-base:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.base_changed == 'true' }}
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: 'Login to GitHub Container Registry'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{github.actor}}
-          password: ${{secrets.GITHUB_TOKEN}}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract version from tag
-        id: extract_version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-
-      - name: Cache Docker layers
-        uses: actions/cache@v3
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-docker-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-docker-
+          context: .
+          file: ./Dockerfile.base.production
+          platforms: linux/amd64
+          push: true
+          cache-from: type=gha,scope=base
+          cache-to: type=gha,scope=base,mode=max
+          tags: |
+            ghcr.io/renedyhr/dyhrene:base
+
+  build:
+    needs: [changes, build-base]
+    if: always() && (needs.build-base.result == 'success' || needs.build-base.result == 'skipped')
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout GitHub Action'
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: 'Login to GitHub Container Registry'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set version
+        id: set_version
+        run: echo "VERSION=${GITHUB_SHA::7}" >> $GITHUB_ENV
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
@@ -45,8 +80,8 @@ jobs:
           file: ./Dockerfile.production
           platforms: linux/amd64
           push: true
-          cache-from: type=gha,scope=project
-          cache-to: type=gha,scope=project,mode=max
+          cache-from: type=gha,scope=app
+          cache-to: type=gha,scope=app,mode=max
           tags: |
             ghcr.io/renedyhr/dyhrene:${{ env.VERSION }}
             ghcr.io/renedyhr/dyhrene:latest

--- a/Dockerfile.base.production
+++ b/Dockerfile.base.production
@@ -1,0 +1,19 @@
+FROM php:8.5-apache
+
+ARG PHP_EXTS="bcmath ctype fileinfo mbstring pdo pdo_mysql intl pcntl zip gd sodium"
+
+RUN apt update \
+    && apt install -y libonig-dev libicu-dev libsodium-dev libxml2-dev libzip-dev zip unzip git libpng-dev libjpeg-dev libfreetype6-dev libwebp-dev cron curl supervisor imagemagick libmagickwand-dev fontconfig fonts-dejavu-core \
+    && docker-php-ext-install -j$(nproc) ${PHP_EXTS} \
+    && pecl install imagick \
+    && docker-php-ext-enable imagick \
+    && a2enmod rewrite \
+    && apt purge -y --auto-remove libonig-dev libxml2-dev libmagickwand-dev \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ENV APACHE_DOCUMENT_ROOT /var/www/html/public
+
+RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
+RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,28 +1,7 @@
-# Stage 1: Base Image with PHP and Required Extensions
-FROM php:8.5-apache as base
+ARG BASE_IMAGE=ghcr.io/renedyhr/dyhrene:base
 
-ARG PHP_EXTS="bcmath ctype fileinfo mbstring pdo pdo_mysql intl pcntl zip gd sodium"
-
-RUN apt update \
-    && apt install -y libonig-dev libicu-dev libsodium-dev libxml2-dev libzip-dev zip libpng-dev libjpeg-dev libfreetype6-dev libwebp-dev cron curl supervisor imagemagick libmagickwand-dev fontconfig fonts-dejavu-core \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && docker-php-ext-install -j$(nproc) ${PHP_EXTS} \
-    && pecl install imagick \
-    && docker-php-ext-enable imagick \
-    && a2enmod rewrite \
-    && apt purge -y --auto-remove libonig-dev libxml2-dev libmagickwand-dev
-
-ENV APACHE_DOCUMENT_ROOT /var/www/html/public
-
-RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
-RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
-
-# Copy Composer from official Composer image
-COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
-
-RUN apt update \
-    && apt install -y zip unzip git \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# Stage 1: Pull pre-built base image
+FROM ${BASE_IMAGE} as base
 
 # Stage 2: Build Stage with Node.js
 FROM node:slim as builder
@@ -32,7 +11,7 @@ WORKDIR /app
 COPY --chown=node:node . /app
 
 # Install frontend dependencies and build assets
-RUN npm install \
+RUN npm ci \
     && npm run build
 
 # Stage 3: Build PHP Application


### PR DESCRIPTION
Extract PHP/extension layer into Dockerfile.base.production so code-only pushes skip the slow apt+pecl install entirely. The docker-publish workflow already conditionally skips the base build when that file is unchanged.

Also:
- Remove dead actions/cache steps (wrote to /tmp but builds used type=gha)
- Separate GHA cache scopes (scope=base / scope=app) to prevent collisions
- Update actions/checkout and docker/login-action to current versions
- Merge two RUN apt layers in Dockerfile.base.production into one
- Use npm ci instead of npm install for deterministic frontend builds